### PR TITLE
add convert-hf-to-powerinfer-gguf.py to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ install(
         WORLD_EXECUTE
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(
-    FILES convert-lora-to-ggml.py
+    FILES convert-hf-to-powerinfer-gguf.py
     PERMISSIONS
         OWNER_READ
         OWNER_WRITE


### PR DESCRIPTION
There is no file called `convert-lora-to-ggml.py` anymore, but there is `convert-hf-to-powerinfer-gguf.py` which wants to be in the output for the build.